### PR TITLE
status cmd: print color in hex

### DIFF
--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -304,7 +304,7 @@ def status():
         click.echo("\nBulb parameters:")
         for key, value in bulb.get_properties().items():
             if key == 'rgb':
-                value = hex(int(value))
+                value = hex(int(value)).replace("0x", "#")
             click.echo("* {}: {}".format(key, value))
 
 

--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -303,6 +303,8 @@ def status():
     for bulb in BULBS:
         click.echo("\nBulb parameters:")
         for key, value in bulb.get_properties().items():
+            if key == 'rgb':
+                value = hex(int(value))
             click.echo("* {}: {}".format(key, value))
 
 


### PR DESCRIPTION
In current implementation, `yee status` command prints current `rgb` color in decimal. This is not convenient, e.g. such number cannot be copy-pasted to command argument.
So this patch should fix that issue by printing color in hex.