### PR TITLE
Fix exception when used with white bulbs

### DIFF
--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -345,7 +345,10 @@ def status():
         click.echo("\nBulb parameters:")
         for key, value in bulb.get_properties().items():
             if key == 'rgb':
-                value = hex(int(value)).replace("0x", "#")
+                try:
+                    value = hex(int(value)).replace("0x", "#")
+                except TypeError:
+                    pass
             click.echo("* {}: {}".format(key, value))
 
 

--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -348,6 +348,7 @@ def status():
                 try:
                     value = hex(int(value)).replace("0x", "#")
                 except TypeError:
+                    # Ignore exception on white-only bulbs.
                     pass
             click.echo("* {}: {}".format(key, value))
 


### PR DESCRIPTION
YeeLight now has white bulbs with adjustable color temp but no RGB, Hue, or Saturation. This prevents the exception when using `yeecli status`.