### PR TITLE
Add stderr output to hex_to_color

### DIFF
--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -30,6 +30,7 @@ def hex_color_to_rgb(color):
     try:
         red, green, blue = tuple(int(color[i:i + 2], 16) for i in (0, 2, 4))
     except (TypeError, ValueError):
+        print('Unrecognized color', file=sys.stderr)
         red, green, blue = (255, 0, 0)
     return red, green, blue
 

--- a/yeecli/cli.py
+++ b/yeecli/cli.py
@@ -30,7 +30,7 @@ def hex_color_to_rgb(color):
     try:
         red, green, blue = tuple(int(color[i:i + 2], 16) for i in (0, 2, 4))
     except (TypeError, ValueError):
-        print('Unrecognized color', file=sys.stderr)
+        print('Unrecognized color, changing to red...', file=sys.stderr)
         red, green, blue = (255, 0, 0)
     return red, green, blue
 


### PR DESCRIPTION
rather than just setting red without telling the user why. 

The bulb showing red without complaint when I clearly issued a bad value that couldn't interpret as red was quite perplexing.